### PR TITLE
Revert "Update maven Docker tag to v3.9.8"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.8-eclipse-temurin-21-jammy as downloadBrowsers
+FROM maven:3.9.7-eclipse-temurin-21-jammy as downloadBrowsers
 
 COPY pom.xml createinstall.sh ./
 RUN mkdir -p /opt/playwright/browsers && chmod -R 777 /opt/playwright


### PR DESCRIPTION
This reverts commit 408a42071ca601d2312af72f8e1758017e18858f.